### PR TITLE
fixed token issue (bug #0927776)

### DIFF
--- a/rules/Microsoft Teams > Send Manual Input link to Microsoft Teams.json
+++ b/rules/Microsoft Teams > Send Manual Input link to Microsoft Teams.json
@@ -46,7 +46,7 @@
     "is_system": false,
     "is_active": true,
     "priority": 10,
-    "event_source": "sealab",
+    "event_source": "crudhub",
     "source": null,
     "channel_preference_field": null,
     "visible": true,


### PR DESCRIPTION
Mantis
----
FortiSOAR token not coming following jinja when manual input Created.
Jinja `{{vars.input.record.token}}`
mantis ID: 0927776
